### PR TITLE
Fix: Set the correct group ID in apache 2.4

### DIFF
--- a/src/mod_mono.c
+++ b/src/mod_mono.c
@@ -403,9 +403,9 @@ apache_get_groupid ()
 {
 #ifdef HAVE_UNIXD
 #if defined(APACHE24)
-	return ap_unixd_config.user_id;
+	return ap_unixd_config.group_id;
 #else
-  return unixd_config.user_id;
+  return unixd_config.group_id;
 #endif
 #else
 	return ap_group_id;


### PR DESCRIPTION
mod-mono-server is run under the wron group ID in apache 2.4. This is due to the fact, that in the function apache_get_groupid the user ID is returned instead of the group ID.
