### PR TITLE
allocate the correct sizes

### DIFF
--- a/src/glib_compat.c
+++ b/src/glib_compat.c
@@ -27,15 +27,15 @@ g_strndup (const char *str, int n)
 static void add_to_vector (gchar ***vector, int size, gchar *token)
 {
         *vector = *vector == NULL ? 
-                (gchar **) malloc (2 * sizeof (*vector)) :
-                (gchar **) realloc (*vector, (size + 1) * sizeof (*vector));
+                (gchar **) malloc (2 * sizeof (**vector)) :
+                (gchar **) realloc (*vector, (size + 1) * sizeof (**vector));
                 
         (*vector)[size - 1] = token;
 }
 
 static gchar **make_empty_vector ()
 {
-	gchar **vector = (gchar**)malloc (2 * sizeof (vector));
+	gchar **vector = (gchar**)malloc (2 * sizeof (*vector));
 	vector [0] = NULL;
 
 	return vector;

--- a/src/mono-io-portability.c
+++ b/src/mono-io-portability.c
@@ -136,7 +136,7 @@ gchar *mono_portability_find_file (int portability_level, const gchar *pathname,
 	}
 
 
-	new_components = (gchar **)g_new0 (gchar **, num_components + 1);
+	new_components = g_new0 (gchar *, num_components + 1);
 
 	if (num_components > 1) {
 		if (strcmp (components[0], "") == 0) {


### PR DESCRIPTION
This is indeed a noop as gchar\* and gchar*\* are both pointers and therefore have the same length. But allocating memory of size sizeof(T) to save the resulting pointer in a T\* variable seems the natural way.
This fixes complaints of  ccc-analyzer/llvm.
A befit of using the correct types is that you no longer need the cast in mono-io-portability.c as the g_new0 macro now already returns the wanted type.
