### PR TITLE
fix the interpretation of MonoCheckHiddenFiles

### DIFF
--- a/src/mod_mono.c
+++ b/src/mod_mono.c
@@ -1760,7 +1760,7 @@ fork_mod_mono_server (apr_pool_t *pool, xsp_data *config)
 	}
 
 	if (config->hidden != NULL) {
-		if (strcasecmp (config->hidden, "false"))
+		if (!strcasecmp (config->hidden, "false"))
 			argv [argi++] = "--no-hidden";
 	}
 	


### PR DESCRIPTION
Setting 'MonoCheckHiddenFiles' to 'false' should result in the
argument '--no-hidden' for the mod-mono-server. According to the
documentation the default value is 'true' therefore omitting the setting
should behave the same as setting it to 'true' which it currently does
not.